### PR TITLE
Update Native AOT docs for preview package caveats

### DIFF
--- a/docs/guides-basic/dotnet-native-aot-support.md
+++ b/docs/guides-basic/dotnet-native-aot-support.md
@@ -6,6 +6,15 @@ Excel-DNA can produce native 64-bit Excel add-ins, that can run on machines that
 [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/)
 deployment and **ExcelDna.AddIn.NativeAOT** package.
 
+## Notes for .NET 10 / preview package users
+
+When using early preview package sets, keep these points in mind:
+
+- Align all `ExcelDna.*` package versions across `ExcelDna.AddIn`, `ExcelDna.Integration`, and `ExcelDna.AddIn.NativeAOT` so they come from the same preview train.
+- The generated build output for NativeAOT variants is typically under a RID-specific path (for example `bin\\<Config>\\<TFM>\\win-x64\\...`) rather than the managed default output path.
+- In preview or custom source setups, `ExcelDnaToolsPath` may need to be set explicitly to ensure the correct `ExcelDna.xll` tooling is used.
+- For automated test setups that reflect-load both managed and NativeAOT assemblies in-process, test harnesses should isolate the loads (for example with `AssemblyLoadContext`) because both outputs are often named the same.
+
 Publishing the following **MyAddin.csproj** C# project produces native 64-bit **MyAddin-AddIn64.xll** Excel add-in:
 
 ```xml
@@ -21,7 +30,7 @@ Publishing the following **MyAddin.csproj** C# project produces native 64-bit **
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExcelDna.AddIn.NativeAOT" Version="0.1.0" />
+    <PackageReference Include="ExcelDna.AddIn.NativeAOT" Version="1.10.0-preview1" />
   </ItemGroup>
 
 </Project>

--- a/docs/guides-basic/dotnet-native-aot-support.md
+++ b/docs/guides-basic/dotnet-native-aot-support.md
@@ -13,7 +13,6 @@ When using early preview package sets (from NuGet.org or another trusted feed), 
 - Align all `ExcelDna.*` package versions across `ExcelDna.AddIn`, `ExcelDna.Integration`, and `ExcelDna.AddIn.NativeAOT` so they come from the same preview train.
 - The generated build output for NativeAOT variants is typically under a RID-specific path (for example `bin\\<Config>\\<TFM>\\win-x64\\...`) rather than the managed default output path.
 - In preview or custom source setups, `ExcelDnaToolsPath` may need to be set explicitly to ensure the correct `ExcelDna.xll` tooling is used.
-- For automated test setups that reflect-load both managed and NativeAOT assemblies in-process, test harnesses should isolate the loads (for example with `AssemblyLoadContext`) because both outputs are often named the same.
 
 Publishing the following **MyAddin.csproj** C# project produces native 64-bit **MyAddin-AddIn64.xll** Excel add-in:
 
@@ -21,7 +20,7 @@ Publishing the following **MyAddin.csproj** C# project produces native 64-bit **
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/docs/guides-basic/dotnet-native-aot-support.md
+++ b/docs/guides-basic/dotnet-native-aot-support.md
@@ -2,7 +2,7 @@
 title: ".NET Native AOT support"
 ---
 
-Excel-DNA can produce native 64-bit Excel add-ins, that can run on machines that don't have the .NET runtime installed, using .NET 8.0 
+Excel-DNA can produce native 64-bit Excel add-ins, that can run on machines that don't have the .NET runtime installed, using .NET 8.0 (or later)
 [Native AOT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/)
 deployment and **ExcelDna.AddIn.NativeAOT** package.
 

--- a/docs/guides-basic/dotnet-native-aot-support.md
+++ b/docs/guides-basic/dotnet-native-aot-support.md
@@ -8,7 +8,7 @@ deployment and **ExcelDna.AddIn.NativeAOT** package.
 
 ## Notes for .NET 10 / preview package users
 
-When using early preview package sets, keep these points in mind:
+When using early preview package sets (from NuGet.org or another trusted feed), keep these points in mind:
 
 - Align all `ExcelDna.*` package versions across `ExcelDna.AddIn`, `ExcelDna.Integration`, and `ExcelDna.AddIn.NativeAOT` so they come from the same preview train.
 - The generated build output for NativeAOT variants is typically under a RID-specific path (for example `bin\\<Config>\\<TFM>\\win-x64\\...`) rather than the managed default output path.

--- a/docs/guides-basic/dotnet-native-aot-support.md
+++ b/docs/guides-basic/dotnet-native-aot-support.md
@@ -12,7 +12,13 @@ When using early preview package sets (from NuGet.org or another trusted feed), 
 
 - Align all `ExcelDna.*` package versions across `ExcelDna.AddIn`, `ExcelDna.Integration`, and `ExcelDna.AddIn.NativeAOT` so they come from the same preview train.
 - The generated build output for NativeAOT variants is typically under a RID-specific path (for example `bin\\<Config>\\<TFM>\\win-x64\\...`) rather than the managed default output path.
-- In preview or custom source setups, `ExcelDnaToolsPath` may need to be set explicitly to ensure the correct `ExcelDna.xll` tooling is used.
+- In preview or custom source setups, if you see a build error like `File does not exist (Xll32FilePath): ... ExcelDna.xll`, you can explicitly point `ExcelDnaToolsPath` at the `ExcelDna.AddIn` package tools folder:
+
+```xml
+<PropertyGroup>
+  <ExcelDnaToolsPath>$(PkgExcelDna_AddIn)\\tools\\</ExcelDnaToolsPath>
+</PropertyGroup>
+```
 
 Publishing the following **MyAddin.csproj** C# project produces native 64-bit **MyAddin-AddIn64.xll** Excel add-in:
 


### PR DESCRIPTION
## Summary
- Add a short notes block to the .NET Native AOT guide for preview/package workflow caveats.
- Call out package version alignment requirements across ExcelDna.* preview packages.
- Document NativeAOT output location differences versus managed outputs.
- Mention explicit ExcelDnaToolsPath in custom/local preview setups.
- Recommend assembly-load isolation for managed+NativeAOT in-process tests. 
- Update sample NativeAOT package version reference to 1.10.0-preview1 to align with current preview stack usage.
